### PR TITLE
Correctly test for power-of-twoness

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 module.exports = isPowerOfTwo
 
 function isPowerOfTwo(n) {
-  // Iterate over every possible power of two, from Number.MIN_VALUE = 2^{-1074} to 2^1023
-  // Note that thanks to the nature of 64-bit floating point arithmetic, all of these results
-  // are precisely accurate
   for (let powerOfTwo = Number.MIN_VALUE; powerOfTwo < Infinity; powerOfTwo *= 2) {
     if (n === powerOfTwo) {
       return true

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
 module.exports = isPowerOfTwo
 
 function isPowerOfTwo(n) {
-  return n !== 0 && (n & (n - 1)) === 0
+  // Iterate over every possible power of two, from Number.MIN_VALUE = 2^{-1074} to 2^1023
+  // Note that thanks to the nature of 64-bit floating point arithmetic, all of these results
+  // are precisely accurate
+  for (let powerOfTwo = Number.MIN_VALUE; powerOfTwo < Infinity; powerOfTwo *= 2) {
+    if (n === powerOfTwo) {
+      return true
+    }
+  }
+  return false
 }

--- a/test.js
+++ b/test.js
@@ -16,5 +16,12 @@ test('whether a number is power of two', function(t) {
   t.equal(isPOT(-16), false)
   t.equal(isPOT(-8), false)
   t.equal(isPOT(-5), false)
+
+  t.equal(isPOT("1"), false)
+  t.equal(isPOT(0.5), true)
+  t.equal(isPOT(Number.MIN_VALUE), true)
+  t.equal(isPOT(-2147483648), false)
+  t.equal(isPOT(4294967297), false)
+  t.equal(isPOT(32.04), false)
   t.end()
 })


### PR DESCRIPTION
Fixes #1.

* Introduces unit tests for all of the inputs described in that issue which previously were not returning the correct result: `"1"`, `-2147483648`, `4294967297` and `32.04`.
* Introduces several additional unit tests for fractional powers of two, `0.5` and `Number.MIN_VALUE` (2<sup>-1074</sup>), which also were not returning the correct result
* Fixes the implementation to pass these tests, by correctly testing for power-of-twoness by iterating over every possible power of two